### PR TITLE
fix overflowing button on small screen

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,7 @@ function HomepageHeader() {
         <h1 className="hero__title">{siteConfig.title}</h1>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
-          <Link className="button button--secondary button--lg" to="docs/tutorials/first_test">
+          <Link className="button button--secondary" to="docs/tutorials/first_test">
             Write Your First Serenity BDD Test in under 10 min ⏱️
           </Link>
         </div>


### PR DESCRIPTION
The home page's CTA button overflows and gets cut in small screens.  Like this:

![image](https://user-images.githubusercontent.com/2035886/188274917-1ca92e47-df0a-4c6c-a7d2-e32f62dddd8d.png)

This pull request is to fix the button's size. Like this:

![image](https://user-images.githubusercontent.com/2035886/188275016-b324a26b-3298-4fb2-9a06-f8d5f3e23d3e.png)