### PR TITLE
Update DuckDuckGo Selectors

### DIFF
--- a/docs/tutorials/first_test.md
+++ b/docs/tutorials/first_test.md
@@ -122,7 +122,7 @@ import net.serenitybdd.core.steps.UIInteractions;
 public class SearchActions extends UIInteractions {
     public void byKeyword(String keyword) {
       $("#searchbox_input").sendKeys(keyword);
-      $(".search__button").click();      
+      $("button[type='submit']").click();      
     }
 }
 ```
@@ -209,7 +209,7 @@ public class SearchActions extends UIInteractions {
     @Step("Search for '{0}'")
     public void byKeyword(String keyword) {
         $("#searchbox_input").sendKeys(keyword);
-        $(".search__button").click();
+        $("button[type='submit']").click();
     }
 }
 ```

--- a/docs/tutorials/first_test.md
+++ b/docs/tutorials/first_test.md
@@ -121,7 +121,7 @@ import net.serenitybdd.core.steps.UIInteractions;
 
 public class SearchActions extends UIInteractions {
     public void byKeyword(String keyword) {
-      $("#search_form_input_homepage").sendKeys(keyword);
+      $("#searchbox_input").sendKeys(keyword);
       $(".search__button").click();      
     }
 }
@@ -208,7 +208,7 @@ import net.thucydides.core.annotations.Step;
 public class SearchActions extends UIInteractions {
     @Step("Search for '{0}'")
     public void byKeyword(String keyword) {
-        $("#search_form_input_homepage").sendKeys(keyword);
+        $("#searchbox_input").sendKeys(keyword);
         $(".search__button").click();
     }
 }


### PR DESCRIPTION
While trying to follow the "Your First Web Test", I noticed that it wasn't working for me.

I looked into it and found that those selectors don't exist anymore; I've replaced them here with ones that do.

However, even with the good selectors, the submit button stays disabled.

![image](https://github.com/serenity-bdd/serenity-bdd.github.io/assets/25108287/1e88d131-7874-40ac-b3b0-6deeb5974731)

I figure this could be a security measure from DDG—or maybe just a bug.

To get around this, you can just send enter, I suppose
`$("#searchbox_input").sendKeys(Keys.ENTER);`