### PR TITLE
docs: Fix `dashboard.excluded.tag.list` formatting

### DIFF
--- a/docs/reference/serenity-properties.md
+++ b/docs/reference/serenity-properties.md
@@ -275,7 +275,8 @@ Display the pie charts on the dashboard by default. If this is set to false, the
 ### dashboard.tag.list
 If set, this will define the list of tag types to appear on the dashboard screens
 
-*dashboard.excluded.tag.list*::If set, this will define the list of tag types to be excluded from the dashboard screens
+### dashboard.excluded.tag.list
+If set, this will define the list of tag types to be excluded from the dashboard screens
 
 ### json.pretty.printing
 Format the JSON test outcomes nicely. "true" or "false", turned off by default.


### PR DESCRIPTION
Previously, the formatting was funny; maybe an old format?

Now, it's formatted the same as the adjacent `dashboard.tag.list`